### PR TITLE
Patch to speed up CoSkeleton

### DIFF
--- a/lib/graphs.gi
+++ b/lib/graphs.gi
@@ -140,8 +140,9 @@ end);
 InstallMethod(CoSkeleton,
 	[IsManiplex],
 	function (m)
-	local p;
-	p:=PointGraph(LayerGraph(Dual(m),0,1));
+	local r, p;
+	r:=Rank(m);
+	p:=PointGraph(LayerGraph(m, r-1, r-2));
 	return p;
 	end);
 


### PR DESCRIPTION
The 0-faces of `Dual(M)` correspond to the (r−1)-faces of M (the facets), where `r = Rank(M)`.
The 1-faces of `Dual(M)` correspond to the (r−2)-faces of M (the ridges).
So the incidence between 0-faces and 1-faces of `Dual(M)` is the same as the incidence between (r−1)-faces and (r−2)-faces of M. That's exactly what `LayerGraph(M, r-1, r-2)` constructs from M's connection group, without going through `Dual` (which is a bottleneck).

## The change

`CoSkeleton(M)` is currently implemented as

```gap
PointGraph(LayerGraph(Dual(m), 0, 1));
```

I propose replacing it with

```gap
PointGraph(LayerGraph(m, Rank(m)-1, Rank(m)-2));
```

Measured speedups on a 200-maniplex sample (rank 4):

Median: ~140× faster.
Range: 7×–3000×.
Aggregate (sum of times): ~200× faster.

## Notes

`Dual(M)` was being computed as a side effect. If any callers were relying on the cached `Dual(M)` attribute being populated after a CoSkeleton call, that side effect is gone.

`Rank(m)` requirement. The new code calls `Rank(m)`, which is set on construction for maniplexes built via `RefManNC` / `ReflexibleManiplex`.

Edge case `r < 2`. The new code uses r-1 and r-2. For rank-1 maniplexes, `r-2 = -1` is invalid for `LayerGraph`. The old code's `Dual` would also fail for `rank ≤ 1`.
