### PR TITLE
Skeleton edges

### DIFF
--- a/lib/graphs.gd
+++ b/lib/graphs.gd
@@ -164,6 +164,68 @@ DeclareOperation("CoSkeleton",[IsManiplex]);
 #! @EndExampleSession
 
 #! @Arguments maniplex
+#! @Returns a record `rec(order, edges)`.
+#! @Description Given a maniplex, this outputs the skeleton as an edge multiset. The record's `order` is the number of 0-faces (the vertices), and `edges` is a list of unordered pairs `[u,v]` of vertex numbers, one per 1-face. Unlike `Skeleton`, which returns the underlying simple graph, this preserves multiple edges (distinct 1-faces sharing the same pair of vertices) and loops (a 1-face whose two ends are the same vertex). The vertex numbering agrees with that of `Skeleton`.
+DeclareOperation("SkeletonEdges",[IsManiplex]);
+#! For the dodecahedron the skeleton is simple, so the multiset has no repeats and matches `Skeleton`.
+#! @BeginExampleSession
+#! gap> s := SkeletonEdges(Dodecahedron());;
+#! gap> s.order;
+#! 20
+#! gap> Length(s.edges);
+#! 30
+#! gap> Length(Set(List(s.edges, Set)));
+#! 30
+#! gap> IsIsomorphicGraph(GraphFromListOfEdges([1..s.order], s.edges), Skeleton(Dodecahedron()));
+#! true
+#! @EndExampleSession
+#! The hosohedron `{2,3}` has a skeleton with three parallel edges, which `Skeleton` collapses to one.
+#! @BeginExampleSession
+#! gap> s := SkeletonEdges(ReflexibleManiplex([2,3]));;
+#! gap> s.order;
+#! 2
+#! gap> Length(s.edges);
+#! 3
+#! gap> Collected(List(s.edges, Set));
+#! [ [ [ 1, 2 ], 3 ] ]
+#! gap> Length(UndirectedEdges(Skeleton(ReflexibleManiplex([2,3]))));
+#! 1
+#! @EndExampleSession
+
+#! @Arguments group
+#! @Returns a record `rec(order, edges)`.
+#! @Description Given a group, assumed to be the connection group of a maniplex, this outputs the skeleton edge multiset, as for the maniplex method above.
+DeclareOperation("SkeletonEdges",[IsGroup]);
+
+#! @Arguments maniplex
+#! @Returns a record `rec(order, edges)`.
+#! @Description Given a maniplex, this outputs the co-skeleton as an edge multiset, i.e. the skeleton edge multiset of the dual. The record's `order` is the number of `(n-1)`-faces, and `edges` is a list of unordered pairs of these, one per `(n-2)`-face. Like `SkeletonEdges`, this preserves multiple edges and loops, where `CoSkeleton` returns only the underlying simple graph.
+DeclareOperation("CoSkeletonEdges",[IsManiplex]);
+#! For the dodecahedron the co-skeleton is simple, so the multiset has no repeats and matches `CoSkeleton`.
+#! @BeginExampleSession
+#! gap> s := CoSkeletonEdges(Dodecahedron());;
+#! gap> s.order;
+#! 12
+#! gap> Length(s.edges);
+#! 30
+#! gap> Length(Set(List(s.edges, Set)));
+#! 30
+#! @EndExampleSession
+#! The co-skeleton of the dihedron `{3,2}` has three parallel edges, which `CoSkeleton` collapses to one.
+#! @BeginExampleSession
+#! gap> s := CoSkeletonEdges(ReflexibleManiplex([3,2]));;
+#! gap> s.order;
+#! 2
+#! gap> Collected(List(s.edges, Set));
+#! [ [ [ 1, 2 ], 3 ] ]
+#! @EndExampleSession
+
+#! @Arguments group
+#! @Returns a record `rec(order, edges)`.
+#! @Description Given a group, assumed to be the connection group of a maniplex, this outputs the co-skeleton edge multiset, as for the maniplex method above.
+DeclareOperation("CoSkeletonEdges",[IsGroup]);
+
+#! @Arguments maniplex
 #! @Returns `IsGraph`. Note this returns a directed graph.
 #! @Description Given a maniplex, this outputs its Hasse diagram as a directed graph.
 #! Note: The unique minimal and maximal faces are assumed.

--- a/lib/graphs.gi
+++ b/lib/graphs.gi
@@ -147,6 +147,59 @@ InstallMethod(CoSkeleton,
 	end);
 
 
+# The skeleton as an edge multiset, preserving multiple edges and loops.
+# Unlike Skeleton, which returns the underlying simple GRAPE graph, this keeps
+# the true multiplicity by building the edges directly from the connection group.
+InstallMethod(SkeletonEdges,
+	[IsGroup],
+	function(c)
+	local gens, n, pts, r0, verts, vertexId, i, f, oneFaces, edges;
+	gens:=GeneratorsOfGroup(c);
+	n:=Size(gens);
+	pts:=MovedPoints(c);
+	r0:=gens[1];
+	# The 0-faces (vertices) are the orbits of <r_1,...,r_{n-1}>.
+	verts:=Orbits(Subgroup(c, gens{[2..n]}), pts);
+	vertexId:=[];
+	for i in [1..Length(verts)] do
+		for f in verts[i] do
+			vertexId[f]:=i;
+		od;
+	od;
+	# The 1-faces (edges) are the orbits of <r_0,r_2,...,r_{n-1}>. For a flag f
+	# in such an orbit, r_0 swaps the two ends of the edge while r_2,...,r_{n-1}
+	# fix the end (they commute with r_0), so f and f^r0 lie in the two incident
+	# 0-faces. Equal ends give a loop; two 1-faces with the same pair of ends
+	# give parallel edges.
+	oneFaces:=Orbits(Subgroup(c, gens{Concatenation([1],[3..n])}), pts);
+	edges:=List(oneFaces, E -> [ vertexId[E[1]], vertexId[E[1]^r0] ]);
+	return rec( order:=Length(verts), edges:=edges );
+end);
+
+
+InstallMethod(SkeletonEdges,
+	[IsManiplex],
+	function(m)
+	return SkeletonEdges(ConnectionGroup(m));
+end);
+
+
+# The co-skeleton is the skeleton of the dual maniplex, whose connection group
+# is obtained by reversing the generator order to (r_{n-1},...,r_0).
+InstallMethod(CoSkeletonEdges,
+	[IsGroup],
+	function(c)
+	return SkeletonEdges(Group(Reversed(GeneratorsOfGroup(c))));
+end);
+
+
+InstallMethod(CoSkeletonEdges,
+	[IsManiplex],
+	function(m)
+	return CoSkeletonEdges(ConnectionGroup(m));
+end);
+
+
 #Want to run this on just connection groups, but have to rebuild f-vectors on the fly.
 InstallMethod(Hasse,
 	[IsManiplex],

--- a/lib/graphs.gi
+++ b/lib/graphs.gi
@@ -156,6 +156,8 @@ InstallMethod(SkeletonEdges,
 	local gens, n, pts, r0, verts, vertexId, i, f, oneFaces, edges;
 	gens:=GeneratorsOfGroup(c);
 	n:=Size(gens);
+	# A rank-0 maniplex (no generators) has an empty skeleton, matching Skeleton.
+	if n = 0 then return rec( order:=0, edges:=[] ); fi;
 	pts:=MovedPoints(c);
 	r0:=gens[1];
 	# The 0-faces (vertices) are the orbits of <r_1,...,r_{n-1}>.
@@ -189,7 +191,10 @@ end);
 InstallMethod(CoSkeletonEdges,
 	[IsGroup],
 	function(c)
-	return SkeletonEdges(Group(Reversed(GeneratorsOfGroup(c))));
+	local gens;
+	gens:=GeneratorsOfGroup(c);
+	if IsEmpty(gens) then return rec( order:=0, edges:=[] ); fi;
+	return SkeletonEdges(Group(Reversed(gens)));
 end);
 
 

--- a/tst/graphs.tst
+++ b/tst/graphs.tst
@@ -67,6 +67,12 @@ gap> s.order;
 2
 gap> Collected(List(s.edges, Set));
 [ [ [ 1, 2 ], 3 ] ]
+gap> s := SkeletonEdges(Vertex());;
+gap> [s.order, Length(s.edges)];
+[ 0, 0 ]
+gap> s := CoSkeletonEdges(Vertex());;
+gap> [s.order, Length(s.edges)];
+[ 0, 0 ]
 gap> g := Hasse(Simplex(3));;
 gap> Length(Vertices(g));
 16

--- a/tst/graphs.tst
+++ b/tst/graphs.tst
@@ -37,6 +37,36 @@ gap> Length(UndirectedEdges(g));
 30
 gap> IsIsomorphicGraph(g,Skeleton(Icosahedron()));
 true
+gap> s := SkeletonEdges(Dodecahedron());;
+gap> s.order;
+20
+gap> Length(s.edges);
+30
+gap> Length(Set(List(s.edges, Set)));
+30
+gap> IsIsomorphicGraph(GraphFromListOfEdges([1..s.order], s.edges), Skeleton(Dodecahedron()));
+true
+gap> s := SkeletonEdges(ReflexibleManiplex([2,3]));;
+gap> s.order;
+2
+gap> Length(s.edges);
+3
+gap> Collected(List(s.edges, Set));
+[ [ [ 1, 2 ], 3 ] ]
+gap> Length(UndirectedEdges(Skeleton(ReflexibleManiplex([2,3]))));
+1
+gap> s := CoSkeletonEdges(Dodecahedron());;
+gap> s.order;
+12
+gap> Length(s.edges);
+30
+gap> Length(Set(List(s.edges, Set)));
+30
+gap> s := CoSkeletonEdges(ReflexibleManiplex([3,2]));;
+gap> s.order;
+2
+gap> Collected(List(s.edges, Set));
+[ [ [ 1, 2 ], 3 ] ]
 gap> g := Hasse(Simplex(3));;
 gap> Length(Vertices(g));
 16

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -2,3 +2,4 @@ rampPath := DirectoriesLibrary("pkg/ramp/tst");
 Test(Filename(rampPath, "duality.tst"));
 Test(Filename(rampPath, "schlafli.tst"));
 Test(Filename(rampPath, "sections.tst"));
+Test(Filename(rampPath, "graphs.tst"));


### PR DESCRIPTION
`Skeleton` and `CoSkeleton` return the underlying *simple* graph, so a maniplex whose skeleton has parallel edges or loops comes back without those. The multiplicity is lost in `LayerGraph` (recorded as 0/1), and GRAPE's `PointGraph` stores adjacency as sets, which cannot hold multiple edges.

This PR adds two functions that return the edge multiset, built directly from the connection group without going through GRAPE:

- `SkeletonEdges(M)` — vertices are the 0-faces, edges are the 1-faces.
- `CoSkeletonEdges(M)` — the skeleton of the dual (vertices the `(n-1)`-faces, edges the `(n-2)`-faces).

Each returns `rec(order, edges)`: `order` is the number of vertices, and `edges` is a multiset of unordered pairs `[u,v]`, with `[u,u]` for a loop. Both also accept a connection group directly.

The change is additive. `Skeleton` and `CoSkeleton` are untouched, so existing callers and tests are unaffected.

The return shape is intentionally graph-format agnostic: rather than prejudge the representation the functions return something neutral that can be wrapped into whichever graph type the RAMP team decides on. If you'd rather it return a specific type now, that's an easy change.

Tests: added to `tst/graphs.tst` a simple polytope (no multiplicity invented; matches `Skeleton`), the non-simple cases (digon, hosohedron, dihedron co-skeleton), and a rank-0 guard. Also added `graphs.tst` to `tst/testall.g`, which was not running it.

I did not regenerate the manual here, happy to do that in a separate commit.

Related: #16 (add graph/skeleton support) and #166 (a better graph type), both closed; #97 (pre-maniplex support), open.
